### PR TITLE
Remove specific user-agent mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,21 +39,6 @@ url1
 [urls...]
 ```
 
-## Webmasters :computer:
-Probably, you see us crawling your website, we announce ourselves as:
-```
-Mozilla/5.0 (compatible; Qwantify/Mermoz/0.1; +https://www.qwant.com/; +https://www.github.com/QwantResearch/mermoz)
-```
-with the following IPs `194.187.171.xxx`.
-
-### :warning: Something wrong? :warning:
-If when we visited your website something went wrong because of our crawler, we are sincerely sorry for
-this inconvenience.
-Actually, Mermoz is a research project still under development and highly perfectible. 
-
-Thus, please tell us what went wrong because of Mermoz by sending a message to this address:
-**mermoz [at] qwantresearch [dot] com**
-
 ## Dependencies
 This list is more or less like a memo:
 - [`urlfactory`](https://www.github.com/QwantResearch/urlfactory) all the needed tools for


### PR DESCRIPTION
There is no interest in documenting a Qwant-specific user-agent here.
Qwant bots are already documented at qwant.com:
- https://help.qwant.com/bot/
- https://about.qwant.com/fr/legal/modalites-de-referencement-dereferencement-et-de-classement/